### PR TITLE
Add public checks to components

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ The `interaction` is the interaction of the component. For an example, if the cu
 ```ts
 module.exports = {
     customId: string,
+    options?: {
+        public?: boolean
+    },
     run: async (client, interaction) => Promise<void>
 };
 ```
@@ -136,6 +139,7 @@ You can use ENV instead of `config.js` to keep your bot token and ID and your Mo
 ```apache
 CLIENT_TOKEN = "Your bot token"
 CLIENT_ID = "Your bot ID"
+GUILD_ID = "Your guild ID"
 MONGODB_URI = "Your mongodb URI string"
 ```
 
@@ -190,6 +194,11 @@ The command options, each property is optional, which means it's allowed to prov
 - `cooldown` (**number**): The cooldown of the command, in milliseconds.
 - `developers` (**boolean**): Whenever the command is executable only to the developers of the bot.
 - `nsfw` (**boolean**): Whenever this command is executable only in NSFW channels.
+
+## Component options
+The component options, each property is optional which means it's allowed to provide an `undefined` value to one of these properties below.
+
+- `public` (**boolean**): If set to true, the component will be available to everyone (default), if set to false, the component will be available to the component owner (original interaction user) only.
 
 ## FAQs
 ### I'm getting this error: "Unable to load application commands to Discord API"

--- a/component.example.txt
+++ b/component.example.txt
@@ -3,6 +3,9 @@ const ExtendedClient = require('../../class/ExtendedClient');
 
 module.exports = {
     customId: '',
+    options: {
+    public: boolean
+    },
     /**
      * 
      * @param {ExtendedClient} client 

--- a/src/events/Guild/components.js
+++ b/src/events/Guild/components.js
@@ -10,34 +10,54 @@ module.exports = {
      * @param {import('discord.js').Interaction} interaction 
      * @returns 
      */
-    run: (client, interaction) => {
+    run: async (client, interaction) => {
+        const componentPermission = async (component) => {
+            if (component.options?.public === false && interaction.user.id !== interaction.message.interaction.user.id) {
+                await interaction.reply({
+                    content:
+                        config.messageSettings.notHasPermissionComponent !== undefined &&
+                        config.messageSettings.notHasPermissionComponent !== null &&
+                        config.messageSettings.notHasPermissionComponent !== ""
+                            ? config.messageSettings.notHasPermissionComponent
+                            : "You do not have permission to use this component",
+                    ephemeral: true
+                });
+                return false;
+            }
+            return true;
+        };
+
         if (interaction.isButton()) {
             const component = client.collection.components.buttons.get(interaction.customId);
 
             if (!component) return;
+            
+            if (!(await componentPermission(component))) return;
 
             try {
                 component.run(client, interaction);
             } catch (error) {
                 log(error, 'error');
-            };
+            }
 
             return;
-        };
+        }
 
         if (interaction.isAnySelectMenu()) {
             const component = client.collection.components.selects.get(interaction.customId);
 
             if (!component) return;
 
+            if (!(await componentPermission(component))) return;
+
             try {
                 component.run(client, interaction);
             } catch (error) {
                 log(error, 'error');
-            };
+            }
 
             return;
-        };
+        }
 
         if (interaction.isModalSubmit()) {
             const component = client.collection.components.modals.get(interaction.customId);

--- a/src/example.config.js
+++ b/src/example.config.js
@@ -29,6 +29,7 @@ module.exports = {
         developerMessage: "You are not authorized to use this command.",
         cooldownMessage: "Slow down buddy! You're too fast to use this command.",
         notHasPermissionMessage: "You do not have the permission to use this command.",
+        notHasPermissionComponent: "You do not have the permission to use this component.",
         missingDevIDsMessage: "This is a developer only command, but unable to execute due to missing user IDs in configuration file."
     }
 };


### PR DESCRIPTION
Add permission checks to components (namely button and select menu)

public: true - allows all users to use the component
public: false - allows only the owner to use the component

Permission checks are not performed on modals as it would be assumed that the interaction (either slash or button) to reach the modal is assumed to have already been passed. Also, no interaction message is passed when a modal is opened only by slash commands, therefore failing most interaction.message.interaction.user.id checks.