### PR TITLE
Fix Mongoose wont connect

### DIFF
--- a/src/class/ExtendedClient.js
+++ b/src/class/ExtendedClient.js
@@ -39,7 +39,7 @@ module.exports = class extends Client {
         events(this);
         components(this);
 
-        if (config.handler.mongodb.toggle) mongoose();
+        if (config.handler.mongodb.enabled) mongoose();
 
         await this.login(process.env.CLIENT_TOKEN || config.client.token);
 


### PR DESCRIPTION
In ExtendClient.js you wirte this:
```js
if (config.handler.mongodb.toggle) mongoose();
```

But in example.config.js you wirte:
```js
mongodb: {
   enabled: false,
   uri: "Your MongoDB URI string (USE .env FOR SAFETY)"
},
```

Which can cause mongoose function will never be called in both bool condition