### PR TITLE
Fix developers structure

### DIFF
--- a/src/events/Guild/messageCreate.js
+++ b/src/events/Guild/messageCreate.js
@@ -74,9 +74,9 @@ module.exports = {
                                         : "You are not authorized to use this command",
                             });
                         }, 5 * 1000);
-                    }
 
-                    return;
+                        return;
+                    }
                 }
 
                 if (command.structure?.nsfw && !message.channel.nsfw) {


### PR DESCRIPTION
This code won't execute the command if the command has the "developers" structure set to true because you placed the return in the wrong scope.