### PR TITLE
chore: bump discord.js to v14.25.0 and fix deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "GPL-3.0",
   "dependencies": {
     "colors": "^1.4.0",
-    "discord.js": "^14.17.0",
+    "discord.js": "^14.25.0",
     "discordjs-v14-bot-template": "file:",
     "dotenv": "^16.4.5",
     "quick-yaml.db": "^1.2.2"

--- a/src/client/handler/CommandOptions.js
+++ b/src/client/handler/CommandOptions.js
@@ -1,4 +1,4 @@
-const { Message } = require("discord.js");
+const { Message, MessageFlags } = require("discord.js");
 const MessageCommand = require("../../structure/MessageCommand");
 const ApplicationCommand = require("../../structure/ApplicationCommand");
 const config = require("../../config");
@@ -18,7 +18,7 @@ const handleApplicationCommandOptions = async (interaction, options, command) =>
         if (interaction.user.id !== config.users.ownerId) {
             await interaction.reply({
                 content: config.messages.NOT_BOT_OWNER,
-                ephemeral: true
+                flags: MessageFlags.Ephemeral
             });
 
             return false;
@@ -29,7 +29,7 @@ const handleApplicationCommandOptions = async (interaction, options, command) =>
         if (config.users?.developers?.length > 0 && !config.users?.developers?.includes(interaction.user.id)) {
             await interaction.reply({
                 content: config.messages.NOT_BOT_DEVELOPER,
-                ephemeral: true
+                flags: MessageFlags.Ephemeral
             });
 
             return false;
@@ -40,7 +40,7 @@ const handleApplicationCommandOptions = async (interaction, options, command) =>
         if (interaction.user.id !== interaction.guild.ownerId) {
             await interaction.reply({
                 content: config.messages.NOT_GUILD_OWNER,
-                ephemeral: true
+                flags: MessageFlags.Ephemeral
             });
 
             return false;
@@ -74,7 +74,7 @@ const handleApplicationCommandOptions = async (interaction, options, command) =>
             if (data.some((cmd) => cmd === interaction.commandName)) {
                 await interaction.reply({
                     content: config.messages.GUILD_COOLDOWN.replace(/%cooldown%/g, options.cooldown / 1000),
-                    ephemeral: true
+                    flags: MessageFlags.Ephemeral
                 });
 
                 return false;

--- a/src/client/handler/CommandsListener.js
+++ b/src/client/handler/CommandsListener.js
@@ -1,4 +1,4 @@
-const { PermissionsBitField, ChannelType } = require("discord.js");
+const { PermissionsBitField, ChannelType, MessageFlags } = require("discord.js");
 const DiscordBot = require("../DiscordBot");
 const config = require("../../config");
 const MessageCommand = require("../../structure/MessageCommand");
@@ -49,7 +49,7 @@ class CommandsListener {
                 if (command.command?.permissions && !message.member.permissions.has(PermissionsBitField.resolve(command.command.permissions))) {
                     await message.reply({
                         content: config.messages.MISSING_PERMISSIONS,
-                        ephemeral: true
+                        flags: MessageFlags.Ephemeral
                     });
 
                     return;

--- a/src/client/handler/ComponentsListener.js
+++ b/src/client/handler/ComponentsListener.js
@@ -1,6 +1,7 @@
 const DiscordBot = require("../DiscordBot");
 const config = require("../../config");
 const { error } = require("../../utils/Console");
+const { MessageFlags } = require("discord.js");
 
 class ComponentsListener {
     /**
@@ -13,7 +14,7 @@ class ComponentsListener {
                 if (component.options?.public === false && interaction.user.id !== interaction.message.interaction.user.id) {
                     await interaction.reply({
                         content: config.messages.COMPONENT_NOT_PUBLIC,
-                        ephemeral: true
+                        flags: MessageFlags.Ephemeral
                     });
 
                     return false;

--- a/src/commands/Other/messagecontext-messageinfo.js
+++ b/src/commands/Other/messagecontext-messageinfo.js
@@ -1,4 +1,4 @@
-const { MessageContextMenuCommandInteraction } = require("discord.js");
+const { MessageContextMenuCommandInteraction, MessageFlags } = require("discord.js");
 const DiscordBot = require("../../client/DiscordBot");
 const ApplicationCommand = require("../../structure/ApplicationCommand");
 
@@ -34,7 +34,7 @@ module.exports = new ApplicationCommand({
 
         await interaction.reply({
             content: array.join('\n'),
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
         });
     }
 }).toJSON();

--- a/src/commands/Other/usercontext-userinfo.js
+++ b/src/commands/Other/usercontext-userinfo.js
@@ -1,4 +1,4 @@
-const { UserContextMenuCommandInteraction } = require("discord.js");
+const { UserContextMenuCommandInteraction, MessageFlags } = require("discord.js");
 const DiscordBot = require("../../client/DiscordBot");
 const ApplicationCommand = require("../../structure/ApplicationCommand");
 
@@ -34,7 +34,7 @@ module.exports = new ApplicationCommand({
 
         await interaction.reply({
             content: array.join('\n'),
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
         });
     }
 }).toJSON();

--- a/src/components/Button/example-button.js
+++ b/src/components/Button/example-button.js
@@ -1,4 +1,4 @@
-const { ButtonInteraction } = require("discord.js");
+const { ButtonInteraction, MessageFlags } = require("discord.js");
 const DiscordBot = require("../../client/DiscordBot");
 const Component = require("../../structure/Component");
 
@@ -14,7 +14,7 @@ module.exports = new Component({
 
         await interaction.reply({
             content: 'Replied from a Button interaction!',
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
         });
 
     }

--- a/src/components/Modal/example-modal.js
+++ b/src/components/Modal/example-modal.js
@@ -1,4 +1,4 @@
-const { ModalSubmitInteraction } = require("discord.js");
+const { ModalSubmitInteraction, MessageFlags } = require("discord.js");
 const DiscordBot = require("../../client/DiscordBot");
 const Component = require("../../structure/Component");
 
@@ -16,7 +16,7 @@ module.exports = new Component({
 
         await interaction.reply({
             content: 'Hello **' + field + '**.',
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
         });
 
     }

--- a/src/components/SelectMenu/example-menu.js
+++ b/src/components/SelectMenu/example-menu.js
@@ -1,5 +1,6 @@
 const DiscordBot = require("../../client/DiscordBot");
 const Component = require("../../structure/Component");
+const { MessageFlags } = require("discord.js");
 
 module.exports = new Component({
     customId: 'example-menu-id',
@@ -13,7 +14,7 @@ module.exports = new Component({
 
         await interaction.reply({
             content: 'Replied from a Select Menu interaction! (You selected **' + interaction.values[0] + '**).',
-            ephemeral: true
+            flags: MessageFlags.Ephemeral
         });
 
     }

--- a/src/events/Client/onReady.js
+++ b/src/events/Client/onReady.js
@@ -2,7 +2,7 @@ const { success } = require("../../utils/Console");
 const Event = require("../../structure/Event");
 
 module.exports = new Event({
-    event: 'ready',
+    event: 'clientReady',
     once: true,
     run: (__client__, client) => {
         success('Logged in as ' + client.user.displayName + ', took ' + ((Date.now() - __client__.login_timestamp) / 1000) + "s.")


### PR DESCRIPTION
This pull request updates DiscordJS from `^14.17.0` to `^14.25.0` and fixes various deprecation warnings.
* Updated the `discord.js` dependency in `package.json` from version `^14.17.0` to `^14.25.0`.
* Replaced the deprecated `ephemeral: true` with `flags: MessageFlags.Ephemeral`.
* Changed the event name from the deprecated `'ready'` to `'clientReady'` in `src/events/Client/onReady.js`.